### PR TITLE
Fixing metadata comparison issue with custom axes

### DIFF
--- a/src/main/java/gigaherz/survivalist/ConfigManager.java
+++ b/src/main/java/gigaherz/survivalist/ConfigManager.java
@@ -254,8 +254,9 @@ public class ConfigManager
     {
         for (Pair<ItemStack, Integer> customAxe : customChoppingAxes)
         {
-            if (ItemStack.areItemsEqual(customAxe.getLeft(), stack))
+            if (customAxe.getLeft().getUnlocalizedName().equalsIgnoreCase(stack.getUnlocalizedName())) {
                 return customAxe.getRight();
+            }
         }
         return -1;
     }

--- a/src/main/java/gigaherz/survivalist/ConfigManager.java
+++ b/src/main/java/gigaherz/survivalist/ConfigManager.java
@@ -254,7 +254,7 @@ public class ConfigManager
     {
         for (Pair<ItemStack, Integer> customAxe : customChoppingAxes)
         {
-            if (customAxe.getLeft().getUnlocalizedName().equalsIgnoreCase(stack.getUnlocalizedName())) {
+            if (ItemStack.areItemsEqualIgnoreDurability(customAxe.getLeft(), stack)) {
                 return customAxe.getRight();
             }
         }


### PR DESCRIPTION
This should fix the issue with damaged custom axes no longer being registered properly, switched to doing a string compare on the item name vs. the item stack check which also included the metadata.

Also switched to spaces not tabs! :)

This is in reference to issue #49 also 