### PR TITLE
Use #forge:gravel instead of minecraft:gravel as recipe ingredient fo…

### DIFF
--- a/src/main/resources/data/forge/tags/items/gravel.json
+++ b/src/main/resources/data/forge/tags/items/gravel.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:gravel"
+  ]
+}

--- a/src/main/resources/data/survivalist/recipes/flint.json
+++ b/src/main/resources/data/survivalist/recipes/flint.json
@@ -1,10 +1,10 @@
 {
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
-    { "item": "minecraft:gravel" },
-    { "item": "minecraft:gravel" },
-    { "item": "minecraft:gravel" },
-    { "item": "minecraft:gravel" }
+    { "tag": "forge:gravel" },
+    { "tag": "forge:gravel" },
+    { "tag": "forge:gravel" },
+    { "tag": "forge:gravel" }
   ],
   "result": {
     "item": "minecraft:flint"

--- a/src/main/resources/data/survivalist/recipes/rocks.json
+++ b/src/main/resources/data/survivalist/recipes/rocks.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
-    { "item": "minecraft:gravel" }
+    { "tag": "forge:gravel" }
   ],
   "result": {
     "item": "survivalist:stone_rock",


### PR DESCRIPTION
…r compatibility with other mod gravels (like Underground Biomes) that use forge:gravel tag

Let me know if you prefer this pull request for the master branch (I'm still on 1.14 myself).